### PR TITLE
Add zig-version-file input to Zig workflows

### DIFF
--- a/.github/workflows/zig-ci.yml
+++ b/.github/workflows/zig-ci.yml
@@ -4,9 +4,19 @@ on:
   workflow_call:
     inputs:
       zig-version:
-        description: Zig version to install (e.g., "0.15.2").
+        description: >-
+          Zig version to install (e.g., "0.15.2"). Takes precedence over
+          zig-version-file. Leave empty to use zig-version-file or to
+          fall back to mlugg/setup-zig's own auto-detection of
+          minimum_zig_version in build.zig.zon.
         type: string
-        required: true
+        default: ""
+      zig-version-file:
+        description: >-
+          Path to a .zon file from which .minimum_zig_version is read
+          (e.g., "build.zig.zon"). Used only when zig-version is empty.
+        type: string
+        default: ""
       runs-on:
         description: >-
           Runner label (ubuntu-latest or macos-latest recommended;
@@ -80,9 +90,34 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
+      - name: Resolve Zig version
+        id: resolve-zig-version
+        shell: bash
+        env:
+          ZIG_VERSION: ${{ inputs.zig-version }}
+          ZIG_VERSION_FILE: ${{ inputs.zig-version-file }}
+        run: |
+          if [ -n "${ZIG_VERSION}" ]; then
+            version="${ZIG_VERSION}"
+          elif [ -n "${ZIG_VERSION_FILE}" ]; then
+            if [ ! -f "${ZIG_VERSION_FILE}" ]; then
+              echo "::error::zig-version-file does not exist: ${ZIG_VERSION_FILE}" >&2
+              exit 1
+            fi
+            zon_pattern='s/^[[:space:]]*\.minimum_zig_version[[:space:]]*=[[:space:]]*"([^"]+)".*/\1/p'
+            version="$(sed -nE "${zon_pattern}" "${ZIG_VERSION_FILE}" | head -n 1)"
+            if [ -z "${version}" ]; then
+              echo "::error::Could not parse .minimum_zig_version from ${ZIG_VERSION_FILE}" >&2
+              exit 1
+            fi
+          else
+            version=""
+          fi
+          echo "version=${version}" >> "${GITHUB_OUTPUT}"
+
       - uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # v2
         with:
-          version: ${{ inputs.zig-version }}
+          version: ${{ steps.resolve-zig-version.outputs.version }}
 
       - name: Run tests
         run: zig build test
@@ -95,9 +130,34 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
+      - name: Resolve Zig version
+        id: resolve-zig-version
+        shell: bash
+        env:
+          ZIG_VERSION: ${{ inputs.zig-version }}
+          ZIG_VERSION_FILE: ${{ inputs.zig-version-file }}
+        run: |
+          if [ -n "${ZIG_VERSION}" ]; then
+            version="${ZIG_VERSION}"
+          elif [ -n "${ZIG_VERSION_FILE}" ]; then
+            if [ ! -f "${ZIG_VERSION_FILE}" ]; then
+              echo "::error::zig-version-file does not exist: ${ZIG_VERSION_FILE}" >&2
+              exit 1
+            fi
+            zon_pattern='s/^[[:space:]]*\.minimum_zig_version[[:space:]]*=[[:space:]]*"([^"]+)".*/\1/p'
+            version="$(sed -nE "${zon_pattern}" "${ZIG_VERSION_FILE}" | head -n 1)"
+            if [ -z "${version}" ]; then
+              echo "::error::Could not parse .minimum_zig_version from ${ZIG_VERSION_FILE}" >&2
+              exit 1
+            fi
+          else
+            version=""
+          fi
+          echo "version=${version}" >> "${GITHUB_OUTPUT}"
+
       - uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # v2
         with:
-          version: ${{ inputs.zig-version }}
+          version: ${{ steps.resolve-zig-version.outputs.version }}
 
       - name: Check formatting
         run: zig fmt --check src/ build.zig
@@ -110,9 +170,34 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
+      - name: Resolve Zig version
+        id: resolve-zig-version
+        shell: bash
+        env:
+          ZIG_VERSION: ${{ inputs.zig-version }}
+          ZIG_VERSION_FILE: ${{ inputs.zig-version-file }}
+        run: |
+          if [ -n "${ZIG_VERSION}" ]; then
+            version="${ZIG_VERSION}"
+          elif [ -n "${ZIG_VERSION_FILE}" ]; then
+            if [ ! -f "${ZIG_VERSION_FILE}" ]; then
+              echo "::error::zig-version-file does not exist: ${ZIG_VERSION_FILE}" >&2
+              exit 1
+            fi
+            zon_pattern='s/^[[:space:]]*\.minimum_zig_version[[:space:]]*=[[:space:]]*"([^"]+)".*/\1/p'
+            version="$(sed -nE "${zon_pattern}" "${ZIG_VERSION_FILE}" | head -n 1)"
+            if [ -z "${version}" ]; then
+              echo "::error::Could not parse .minimum_zig_version from ${ZIG_VERSION_FILE}" >&2
+              exit 1
+            fi
+          else
+            version=""
+          fi
+          echo "version=${version}" >> "${GITHUB_OUTPUT}"
+
       - uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # v2
         with:
-          version: ${{ inputs.zig-version }}
+          version: ${{ steps.resolve-zig-version.outputs.version }}
 
       - name: Build
         run: zig build
@@ -125,9 +210,34 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
+      - name: Resolve Zig version
+        id: resolve-zig-version
+        shell: bash
+        env:
+          ZIG_VERSION: ${{ inputs.zig-version }}
+          ZIG_VERSION_FILE: ${{ inputs.zig-version-file }}
+        run: |
+          if [ -n "${ZIG_VERSION}" ]; then
+            version="${ZIG_VERSION}"
+          elif [ -n "${ZIG_VERSION_FILE}" ]; then
+            if [ ! -f "${ZIG_VERSION_FILE}" ]; then
+              echo "::error::zig-version-file does not exist: ${ZIG_VERSION_FILE}" >&2
+              exit 1
+            fi
+            zon_pattern='s/^[[:space:]]*\.minimum_zig_version[[:space:]]*=[[:space:]]*"([^"]+)".*/\1/p'
+            version="$(sed -nE "${zon_pattern}" "${ZIG_VERSION_FILE}" | head -n 1)"
+            if [ -z "${version}" ]; then
+              echo "::error::Could not parse .minimum_zig_version from ${ZIG_VERSION_FILE}" >&2
+              exit 1
+            fi
+          else
+            version=""
+          fi
+          echo "version=${version}" >> "${GITHUB_OUTPUT}"
+
       - uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # v2
         with:
-          version: ${{ inputs.zig-version }}
+          version: ${{ steps.resolve-zig-version.outputs.version }}
 
       - name: Cross compile
         shell: bash
@@ -148,9 +258,34 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
+      - name: Resolve Zig version
+        id: resolve-zig-version
+        shell: bash
+        env:
+          ZIG_VERSION: ${{ inputs.zig-version }}
+          ZIG_VERSION_FILE: ${{ inputs.zig-version-file }}
+        run: |
+          if [ -n "${ZIG_VERSION}" ]; then
+            version="${ZIG_VERSION}"
+          elif [ -n "${ZIG_VERSION_FILE}" ]; then
+            if [ ! -f "${ZIG_VERSION_FILE}" ]; then
+              echo "::error::zig-version-file does not exist: ${ZIG_VERSION_FILE}" >&2
+              exit 1
+            fi
+            zon_pattern='s/^[[:space:]]*\.minimum_zig_version[[:space:]]*=[[:space:]]*"([^"]+)".*/\1/p'
+            version="$(sed -nE "${zon_pattern}" "${ZIG_VERSION_FILE}" | head -n 1)"
+            if [ -z "${version}" ]; then
+              echo "::error::Could not parse .minimum_zig_version from ${ZIG_VERSION_FILE}" >&2
+              exit 1
+            fi
+          else
+            version=""
+          fi
+          echo "version=${version}" >> "${GITHUB_OUTPUT}"
+
       - uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # v2
         with:
-          version: ${{ inputs.zig-version }}
+          version: ${{ steps.resolve-zig-version.outputs.version }}
 
       - name: Scrut test setup
         if: inputs.scrut-setup-cmd != ''

--- a/.github/workflows/zig-ci.yml
+++ b/.github/workflows/zig-ci.yml
@@ -113,6 +113,10 @@ jobs:
           else
             version=""
           fi
+          if [[ -n "${version}" && ! "${version}" =~ ^[A-Za-z0-9._+-]+$ ]]; then
+            echo "::error::Resolved Zig version contains invalid characters" >&2
+            exit 1
+          fi
           echo "version=${version}" >> "${GITHUB_OUTPUT}"
 
       - uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # v2
@@ -152,6 +156,10 @@ jobs:
             fi
           else
             version=""
+          fi
+          if [[ -n "${version}" && ! "${version}" =~ ^[A-Za-z0-9._+-]+$ ]]; then
+            echo "::error::Resolved Zig version contains invalid characters" >&2
+            exit 1
           fi
           echo "version=${version}" >> "${GITHUB_OUTPUT}"
 
@@ -193,6 +201,10 @@ jobs:
           else
             version=""
           fi
+          if [[ -n "${version}" && ! "${version}" =~ ^[A-Za-z0-9._+-]+$ ]]; then
+            echo "::error::Resolved Zig version contains invalid characters" >&2
+            exit 1
+          fi
           echo "version=${version}" >> "${GITHUB_OUTPUT}"
 
       - uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # v2
@@ -232,6 +244,10 @@ jobs:
             fi
           else
             version=""
+          fi
+          if [[ -n "${version}" && ! "${version}" =~ ^[A-Za-z0-9._+-]+$ ]]; then
+            echo "::error::Resolved Zig version contains invalid characters" >&2
+            exit 1
           fi
           echo "version=${version}" >> "${GITHUB_OUTPUT}"
 
@@ -280,6 +296,10 @@ jobs:
             fi
           else
             version=""
+          fi
+          if [[ -n "${version}" && ! "${version}" =~ ^[A-Za-z0-9._+-]+$ ]]; then
+            echo "::error::Resolved Zig version contains invalid characters" >&2
+            exit 1
           fi
           echo "version=${version}" >> "${GITHUB_OUTPUT}"
 

--- a/.github/workflows/zig-release.yml
+++ b/.github/workflows/zig-release.yml
@@ -79,6 +79,10 @@ jobs:
           else
             version=""
           fi
+          if [[ -n "${version}" && ! "${version}" =~ ^[A-Za-z0-9._+-]+$ ]]; then
+            echo "::error::Resolved Zig version contains invalid characters" >&2
+            exit 1
+          fi
           echo "version=${version}" >> "${GITHUB_OUTPUT}"
 
       - uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # v2

--- a/.github/workflows/zig-release.yml
+++ b/.github/workflows/zig-release.yml
@@ -4,9 +4,19 @@ on:
   workflow_call:
     inputs:
       zig-version:
-        description: Zig version to install (e.g., "0.15.2").
+        description: >-
+          Zig version to install (e.g., "0.15.2"). Takes precedence over
+          zig-version-file. Leave empty to use zig-version-file or to
+          fall back to mlugg/setup-zig's own auto-detection of
+          minimum_zig_version in build.zig.zon.
         type: string
-        required: true
+        default: ""
+      zig-version-file:
+        description: >-
+          Path to a .zon file from which .minimum_zig_version is read
+          (e.g., "build.zig.zon"). Used only when zig-version is empty.
+        type: string
+        default: ""
       binary-name:
         description: Name of the binary to build and package (e.g., "seine").
         type: string
@@ -46,9 +56,34 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Resolve Zig version
+        id: resolve-zig-version
+        shell: bash
+        env:
+          ZIG_VERSION: ${{ inputs.zig-version }}
+          ZIG_VERSION_FILE: ${{ inputs.zig-version-file }}
+        run: |
+          if [ -n "${ZIG_VERSION}" ]; then
+            version="${ZIG_VERSION}"
+          elif [ -n "${ZIG_VERSION_FILE}" ]; then
+            if [ ! -f "${ZIG_VERSION_FILE}" ]; then
+              echo "::error::zig-version-file does not exist: ${ZIG_VERSION_FILE}" >&2
+              exit 1
+            fi
+            zon_pattern='s/^[[:space:]]*\.minimum_zig_version[[:space:]]*=[[:space:]]*"([^"]+)".*/\1/p'
+            version="$(sed -nE "${zon_pattern}" "${ZIG_VERSION_FILE}" | head -n 1)"
+            if [ -z "${version}" ]; then
+              echo "::error::Could not parse .minimum_zig_version from ${ZIG_VERSION_FILE}" >&2
+              exit 1
+            fi
+          else
+            version=""
+          fi
+          echo "version=${version}" >> "${GITHUB_OUTPUT}"
+
       - uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # v2
         with:
-          version: ${{ inputs.zig-version }}
+          version: ${{ steps.resolve-zig-version.outputs.version }}
 
       - name: Build and package
         shell: bash

--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -17,6 +17,7 @@
     "MD060": false,
   },
 
-  // Files to ignore
-  "ignores": ["node_modules/", "CHANGELOG.md"],
+  // Files to ignore. .workmux/ holds workmux-generated worktree
+  // scratchpads (gitignored locally); not project content.
+  "ignores": ["node_modules/", "CHANGELOG.md", ".workmux/"],
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `zig-version-file` input on `zig-ci.yml` and `zig-release.yml`,
+  mirroring `node-version-file` / `go-version-file` /
+  `ruby-version-file` in upstream setup actions. Callers can now point
+  the workflow at a `.zon` file (typically `build.zig.zon`) and the
+  workflow reads `.minimum_zig_version` from it instead of requiring a
+  literal version string. `zig-version` is now optional (default
+  `""`); when both inputs are set, `zig-version` takes precedence.
+  When neither is set, `mlugg/setup-zig` falls back to its own
+  auto-detection (#41)
 - Dependabot config (`.github/dependabot.yml`) covering both
   `github-actions` (workflows + composite actions with external `uses:`)
   and `npm` (devDependencies). Minor/patch updates are grouped weekly;

--- a/README.md
+++ b/README.md
@@ -730,7 +730,8 @@ targets) since Zig projects idiomatically use `build.zig` as their build system.
 
 | Name                | Type    | Default         | Description                                          |
 | ------------------- | ------- | --------------- | ---------------------------------------------------- |
-| `zig-version`       | string  |                 | Zig version to install (required)                    |
+| `zig-version`       | string  | `""`            | Zig version to install (e.g., `"0.15.2"`)            |
+| `zig-version-file`  | string  | `""`            | Path to a `.zon` file with `.minimum_zig_version`    |
 | `runs-on`           | string  | `ubuntu-latest` | Runner label (Windows is not supported)              |
 | `run-test`          | boolean | `true`          | Run `zig build test`                                 |
 | `run-fmt`           | boolean | `true`          | Run `zig fmt --check src/ build.zig`                 |
@@ -750,7 +751,14 @@ Default `cross-targets`:
 x86_64-linux-gnu aarch64-linux-gnu x86_64-macos aarch64-macos x86_64-windows-gnu
 ```
 
+Specify exactly one of `zig-version` or `zig-version-file`. If both are
+set, `zig-version` takes precedence. If neither is set, `mlugg/setup-zig`
+falls back to its own auto-detection (reads `minimum_zig_version` from
+`build.zig.zon`, or installs `latest` if no `build.zig.zon` is present).
+
 #### Usage
+
+With an explicit version:
 
 ```yaml
 jobs:
@@ -761,6 +769,17 @@ jobs:
       run-cross-compile: true
 ```
 
+Reading the version from `build.zig.zon`:
+
+```yaml
+jobs:
+  ci:
+    uses: cboone/gh-actions/.github/workflows/zig-ci.yml@v2.1.4
+    with:
+      zig-version-file: build.zig.zon
+      run-cross-compile: true
+```
+
 With scrut CLI tests:
 
 ```yaml
@@ -768,7 +787,7 @@ jobs:
   ci:
     uses: cboone/gh-actions/.github/workflows/zig-ci.yml@v2.1.4
     with:
-      zig-version: "0.14.1"
+      zig-version-file: build.zig.zon
       run-scrut: true
       scrut-build-cmd: "zig build"
       scrut-env: |
@@ -785,20 +804,25 @@ cross-compilation from a single runner (no matrix, no macOS runners).
 
 #### Inputs
 
-| Name              | Type   | Default         | Description                          |
-| ----------------- | ------ | --------------- | ------------------------------------ |
-| `zig-version`     | string |                 | Zig version to install (required)    |
-| `binary-name`     | string |                 | Name of the binary (required)        |
-| `targets`         | string | (see below)     | Space-separated Zig target triples   |
-| `optimize`        | string | `ReleaseSafe`   | Zig optimization level               |
-| `runs-on`         | string | `ubuntu-latest` | Runner label (Windows not supported) |
-| `timeout-minutes` | number | `30`            | Job timeout in minutes               |
+| Name               | Type   | Default         | Description                                       |
+| ------------------ | ------ | --------------- | ------------------------------------------------- |
+| `zig-version`      | string | `""`            | Zig version to install (e.g., `"0.15.2"`)         |
+| `zig-version-file` | string | `""`            | Path to a `.zon` file with `.minimum_zig_version` |
+| `binary-name`      | string |                 | Name of the binary (required)                     |
+| `targets`          | string | (see below)     | Space-separated Zig target triples                |
+| `optimize`         | string | `ReleaseSafe`   | Zig optimization level                            |
+| `runs-on`          | string | `ubuntu-latest` | Runner label (Windows not supported)              |
+| `timeout-minutes`  | number | `30`            | Job timeout in minutes                            |
 
 Default `targets`:
 
 ```text
 x86_64-linux-gnu aarch64-linux-gnu x86_64-macos aarch64-macos x86_64-windows-gnu
 ```
+
+`zig-version` and `zig-version-file` follow the same precedence rules as
+in `zig-ci.yml`: `zig-version` wins if both are set, and if neither is
+set `mlugg/setup-zig` falls back to its own auto-detection.
 
 #### Usage
 
@@ -807,7 +831,7 @@ jobs:
   release:
     uses: cboone/gh-actions/.github/workflows/zig-release.yml@v2.1.4
     with:
-      zig-version: "0.14.1"
+      zig-version-file: build.zig.zon
       binary-name: "my-tool"
 ```
 

--- a/README.md
+++ b/README.md
@@ -751,7 +751,7 @@ Default `cross-targets`:
 x86_64-linux-gnu aarch64-linux-gnu x86_64-macos aarch64-macos x86_64-windows-gnu
 ```
 
-Specify exactly one of `zig-version` or `zig-version-file`. If both are
+Specify at most one of `zig-version` or `zig-version-file`. If both are
 set, `zig-version` takes precedence. If neither is set, `mlugg/setup-zig`
 falls back to its own auto-detection (reads `minimum_zig_version` from
 `build.zig.zon`, or installs `latest` if no `build.zig.zon` is present).


### PR DESCRIPTION
## Summary

- Make `zig-version` optional and add a new `zig-version-file` input on
  `zig-ci.yml` and `zig-release.yml`, mirroring the
  `node-version-file` / `go-version-file` / `ruby-version-file` pattern
  in upstream setup actions.
- When `zig-version-file` is set, the workflow parses
  `.minimum_zig_version` from the referenced `.zon` file (works for any
  path, not just `build.zig.zon`) and feeds the result to
  `mlugg/setup-zig`'s `version:` input. This avoids relying on
  setup-zig's silent `latest` fallback when a misnamed file is provided.
- Precedence: `zig-version` wins if both are set; if neither is set,
  `mlugg/setup-zig` falls back to its own auto-detection
  (`build.zig.zon` then `latest`). Documented in the README.
- Companion fix: add `.workmux/` to `.markdownlint-cli2.jsonc` ignores
  so workmux-generated worktree scratchpads do not break `make lint-md`.

## Implementation note

`mlugg/setup-zig@d1434d08` (v2) does not actually expose a `version-file:`
input as the linked issue's pseudocode suggested; its docs describe the
empty-`version:` build.zig.zon fallback. So the workflow parses the
`.zon` file itself with `sed` (extracting
`.minimum_zig_version = "X.Y.Z"`) and passes the result to setup-zig's
`version:`. This makes `zig-version-file` meaningful for any path and
errors out clearly if the file is missing or has no
`.minimum_zig_version` field.

## Test plan

- [ ] Confirm `make lint`, `make lint-yaml`, `make format-check`,
      `make spell`, and `make lint-md` all pass on this branch.
- [ ] After release, smoke-test a downstream consumer with
      `zig-version-file: build.zig.zon` (planned via cboone-cc-plugins
      follow-up: cboone/cboone-cc-plugins#249).

## Closes

Closes #41
