### PR TITLE
feat: add homebrew-desc input to release-rust-binaries.yml

### DIFF
--- a/.github/workflows/release-rust-binaries.yml
+++ b/.github/workflows/release-rust-binaries.yml
@@ -72,6 +72,12 @@ on:
           system bin/"<binary>", "--version"
         type: string
         default: ""
+      homebrew-desc:
+        description: >-
+          Description for the Homebrew formula. When empty, defaults to
+          the binary name.
+        type: string
+        default: ""
       timeout-minutes:
         description: Job timeout in minutes.
         type: number
@@ -289,6 +295,7 @@ jobs:
           REPO: ${{ github.repository }}
           LICENSE: ${{ inputs.homebrew-license }}
           HOMEBREW_TEST: ${{ inputs.homebrew-test }}
+          DESC: ${{ inputs.homebrew-desc }}
         run: |
           if [ -n "${ARCHIVE_PREFIX}" ]; then
             prefix="${ARCHIVE_PREFIX}"
@@ -319,10 +326,12 @@ jobs:
             | awk '{for(i=1;i<=NF;i++) $i=toupper(substr($i,1,1)) substr($i,2)}1' \
             | tr -d ' ')"
 
+          desc="${DESC:-${BINARY}}"
+
           # Write formula file using a command group
           {
             echo "class ${class_name} < Formula"
-            echo "  desc \"${BINARY}\""
+            echo "  desc \"${desc}\""
             echo "  homepage \"https://github.com/${REPO}\""
             echo "  version \"${VERSION}\""
             echo "  license \"${LICENSE}\""

--- a/.github/workflows/release-rust-binaries.yml
+++ b/.github/workflows/release-rust-binaries.yml
@@ -326,7 +326,14 @@ jobs:
             | awk '{for(i=1;i<=NF;i++) $i=toupper(substr($i,1,1)) substr($i,2)}1' \
             | tr -d ' ')"
 
-          desc="${DESC:-${BINARY}}"
+          # Escape for Ruby double-quoted strings: backslash, double quote,
+          # and # (the last to prevent #{...} interpolation). Strip CR and
+          # replace LF with space to keep the formula on one line.
+          desc_raw="${DESC:-${BINARY}}"
+          desc="$(printf '%s' "${desc_raw}" \
+            | tr -d '\r' \
+            | tr '\n' ' ' \
+            | sed -e 's/\\/\\\\/g' -e 's/"/\\"/g' -e 's/#/\\#/g')"
 
           # Write formula file using a command group
           {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `presets/lean-math/`. Targets Lean + paper-backed formalization
   repos (`shannon-entropy`, `zhang-yeung-inequality`,
   `strength-model`) that previously carried duplicated configs
+- `homebrew-desc` input on `release-rust-binaries.yml` for setting the
+  generated Homebrew formula's `desc` field. Defaults to the binary
+  name when empty, preserving prior behavior (#30)
 
 ## [3.0.0] - 2026-05-02
 

--- a/docs/workflows/release-rust-binaries.md
+++ b/docs/workflows/release-rust-binaries.md
@@ -27,6 +27,7 @@ workflow fails fast.
 | `homebrew-formula-path` | string  | `""`                  | Path to the formula in the tap repo (e.g. Formula/mytool.rb) |
 | `homebrew-license`      | string  | `"MIT"`               | SPDX license identifier for the Homebrew formula             |
 | `homebrew-test`         | string  | `""`                  | Custom Ruby body for the formula `test do` block             |
+| `homebrew-desc`         | string  | `""`                  | Description for the Homebrew formula (defaults to binary)    |
 | `timeout-minutes`       | number  | `30`                  | Job timeout in minutes                                       |
 
 ## Secrets


### PR DESCRIPTION
## Summary

- Add `homebrew-desc` input to `release-rust-binaries.yml` so callers can set a descriptive `desc` field on the generated Homebrew formula instead of the bare binary name.
- Default to the binary name when the input is empty, preserving prior behavior for existing callers.
- Document the input in `docs/workflows/release-rust-binaries.md` and add an `[Unreleased]` CHANGELOG entry.

## Test plan

- [ ] After merge and release, consume from cboone/ke#2 with `homebrew-desc: "A developer-focused CLI for ergonomic macOS Keychain access"` and verify the resulting `Formula/ke.rb` carries that string in its `desc` line.
- [ ] Verify an existing consumer that does not set `homebrew-desc` still produces a formula with `desc "${BINARY}"` (unchanged).

## Closes

Closes #30
