### PR TITLE
feat: add homebrew-test input to release-rust-binaries.yml

### DIFF
--- a/.github/workflows/release-rust-binaries.yml
+++ b/.github/workflows/release-rust-binaries.yml
@@ -64,6 +64,14 @@ on:
           (e.g. MIT, Apache-2.0). Defaults to MIT.
         type: string
         default: "MIT"
+      homebrew-test:
+        description: >-
+          Custom Ruby code for the Homebrew formula test block. The
+          value is inserted inside the generated `test do ... end`
+          block, indented to match. When empty, defaults to:
+          system bin/"<binary>", "--version"
+        type: string
+        default: ""
       timeout-minutes:
         description: Job timeout in minutes.
         type: number
@@ -280,6 +288,7 @@ jobs:
           FORMULA_PATH: ${{ inputs.homebrew-formula-path }}
           REPO: ${{ github.repository }}
           LICENSE: ${{ inputs.homebrew-license }}
+          HOMEBREW_TEST: ${{ inputs.homebrew-test }}
         run: |
           if [ -n "${ARCHIVE_PREFIX}" ]; then
             prefix="${ARCHIVE_PREFIX}"
@@ -369,7 +378,11 @@ jobs:
             echo "  end"
             echo ""
             echo "  test do"
-            echo "    system bin/\"${BINARY}\", \"--version\""
+            if [ -n "${HOMEBREW_TEST}" ]; then
+              printf '%s\n' "${HOMEBREW_TEST%$'\n'}" | sed '/./s/^/    /'
+            else
+              echo "    system bin/\"${BINARY}\", \"--version\""
+            fi
             echo "  end"
             echo "end"
           } > "homebrew-tap/${FORMULA_PATH}"

--- a/docs/workflows/release-rust-binaries.md
+++ b/docs/workflows/release-rust-binaries.md
@@ -26,6 +26,7 @@ workflow fails fast.
 | `homebrew-tap`          | string  | `""`                  | Homebrew tap repository (e.g. user/homebrew-tap)             |
 | `homebrew-formula-path` | string  | `""`                  | Path to the formula in the tap repo (e.g. Formula/mytool.rb) |
 | `homebrew-license`      | string  | `"MIT"`               | SPDX license identifier for the Homebrew formula             |
+| `homebrew-test`         | string  | `""`                  | Custom Ruby body for the formula `test do` block             |
 | `timeout-minutes`       | number  | `30`                  | Job timeout in minutes                                       |
 
 ## Secrets
@@ -67,3 +68,35 @@ jobs:
     secrets:
       HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
 ```
+
+By default the generated formula's test block is:
+
+```ruby
+test do
+  system bin/"<binary>", "--version"
+end
+```
+
+To assert against the binary's output instead, pass `homebrew-test`:
+
+```yaml
+jobs:
+  release:
+    uses: cboone/gh-actions/.github/workflows/release-rust-binaries.yml@v3.0.0
+    with:
+      targets: >-
+        [
+          {"target": "aarch64-apple-darwin", "runner": "macos-latest"},
+          {"target": "x86_64-unknown-linux-gnu", "runner": "ubuntu-latest"}
+        ]
+      update-homebrew: true
+      homebrew-tap: myuser/homebrew-tap
+      homebrew-formula-path: Formula/mytool.rb
+      homebrew-test: |
+        assert_match version.to_s, shell_output("#{bin}/mytool --version")
+    secrets:
+      HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+```
+
+The value is indented to match the formula's `test do` block, so write
+it at column 0. Multi-line bodies are supported.


### PR DESCRIPTION
## Summary

- Add a `homebrew-test` input to `release-rust-binaries.yml` so callers can supply a custom Ruby body for the generated formula's `test do` block, instead of being stuck with the hardcoded `system bin/"<binary>", "--version"`.
- Wire the input through to the formula-generation step. Multi-line bodies are supported: the value is `printf`-emitted with one trailing newline stripped (so YAML `|` does not produce a blank line) and piped through `sed '/./s/^/    /'` to indent non-empty lines by four spaces, leaving internal blank lines unpadded.
- When the input is empty (the default), the previous hardcoded test line is emitted unchanged, so existing callers are unaffected.
- Update `docs/workflows/release-rust-binaries.md` with a row in the inputs table and a usage example showing `assert_match version.to_s, shell_output("#{bin}/mytool --version")`.

## Test plan

- [ ] Local simulation of the test-block emission confirmed correct output for: single-line custom body, multi-line custom body, empty input (default fallback), and a body containing internal blank lines.
- [ ] `make lint` (actionlint), `make lint-yaml`, `make lint-md`, `make format-check`, `make spell` all pass.
- [ ] On `cboone/ke#2`, switch the consumer's `homebrew-test` to `assert_match version.to_s, shell_output("#{bin}/ke --version")` and confirm the generated formula contains the new test block on the next tagged release.

## Closes

Closes #32
