### PR TITLE
feat(lint-text): add use-consumer-versions input

### DIFF
--- a/.github/workflows/lint-text.yml
+++ b/.github/workflows/lint-text.yml
@@ -159,7 +159,7 @@ jobs:
           fi
 
       - name: Install lint tools (sha512-verified via gh-actions lockfile)
-        if: ${{ !inputs.use-consumer-versions }}
+        if: ${{ !inputs.use-consumer-versions && (inputs.run-markdownlint || inputs.run-prettier || inputs.run-cspell) }}
         env:
           # Pin package.json + package-lock.json to the same SHA as this
           # workflow so a tampered registry response cannot slip past npm
@@ -178,7 +178,7 @@ jobs:
           base="https://raw.githubusercontent.com/cboone/gh-actions/${REQ_SHA}"
           curl -sSfL "${base}/package.json"      -o "${install_dir}/package.json"
           curl -sSfL "${base}/package-lock.json" -o "${install_dir}/package-lock.json"
-          (cd "${install_dir}" && npm ci --ignore-scripts --no-audit --no-fund)
+          (cd "${install_dir}" && npm ci --ignore-scripts --include=dev --no-audit --no-fund)
           printf '%s\n' "${install_dir}/node_modules/.bin" >> "${GITHUB_PATH}"
 
       - name: Install lint tools (consumer's package-lock.json)
@@ -201,7 +201,7 @@ jobs:
             echo "::error::${msg}" >&2
             exit 1
           fi
-          npm ci --ignore-scripts --no-audit --no-fund
+          npm ci --ignore-scripts --include=dev --no-audit --no-fund
           printf '%s\n' "${GITHUB_WORKSPACE}/node_modules/.bin" >> "${GITHUB_PATH}"
 
       - name: Run markdownlint

--- a/.github/workflows/lint-text.yml
+++ b/.github/workflows/lint-text.yml
@@ -159,7 +159,9 @@ jobs:
           fi
 
       - name: Install lint tools (sha512-verified via gh-actions lockfile)
-        if: ${{ !inputs.use-consumer-versions && (inputs.run-markdownlint || inputs.run-prettier || inputs.run-cspell) }}
+        if: >-
+          ${{ !inputs.use-consumer-versions
+          && (inputs.run-markdownlint || inputs.run-prettier || inputs.run-cspell) }}
         env:
           # Pin package.json + package-lock.json to the same SHA as this
           # workflow so a tampered registry response cannot slip past npm

--- a/.github/workflows/lint-text.yml
+++ b/.github/workflows/lint-text.yml
@@ -34,6 +34,19 @@ on:
           ignores).
         type: string
         default: ""
+      use-consumer-versions:
+        description: |
+          When true, install markdownlint-cli2, Prettier, and cspell
+          from the consumer repo's own package.json + package-lock.json
+          (via `npm ci` in the workspace) instead of the versions
+          pinned in this gh-actions repo. Use this when local linting
+          and CI must agree on tool versions. The consumer is then
+          responsible for their lockfile's integrity: a committed
+          package-lock.json with sha512 integrity hashes is required,
+          and every enabled tool must be a devDependency. yamllint is
+          unaffected (Python, not npm).
+        type: boolean
+        default: false
       timeout-minutes:
         description: Job timeout in minutes.
         type: number
@@ -146,6 +159,7 @@ jobs:
           fi
 
       - name: Install lint tools (sha512-verified via gh-actions lockfile)
+        if: ${{ !inputs.use-consumer-versions }}
         env:
           # Pin package.json + package-lock.json to the same SHA as this
           # workflow so a tampered registry response cannot slip past npm
@@ -166,6 +180,29 @@ jobs:
           curl -sSfL "${base}/package-lock.json" -o "${install_dir}/package-lock.json"
           (cd "${install_dir}" && npm ci --ignore-scripts --no-audit --no-fund)
           printf '%s\n' "${install_dir}/node_modules/.bin" >> "${GITHUB_PATH}"
+
+      - name: Install lint tools (consumer's package-lock.json)
+        if: ${{ inputs.use-consumer-versions && (inputs.run-markdownlint || inputs.run-prettier || inputs.run-cspell) }}
+        # Install from the consumer's own committed package-lock.json
+        # rather than this repo's lockfile. npm ci still enforces
+        # per-package sha512 integrity, so the trust boundary becomes
+        # the consumer's reviewed lockfile rather than this gh-actions
+        # repo. The consumer is responsible for committing
+        # package-lock.json and listing every enabled tool as a
+        # devDependency.
+        run: |
+          if [ ! -f package.json ]; then
+            echo "::error::use-consumer-versions=true but package.json is missing in the consumer repo." >&2
+            exit 1
+          fi
+          if [ ! -f package-lock.json ]; then
+            msg="use-consumer-versions=true but package-lock.json is missing in the consumer repo."
+            msg="${msg} Run 'npm install' locally and commit the lockfile."
+            echo "::error::${msg}" >&2
+            exit 1
+          fi
+          npm ci --ignore-scripts --no-audit --no-fund
+          printf '%s\n' "${GITHUB_WORKSPACE}/node_modules/.bin" >> "${GITHUB_PATH}"
 
       - name: Run markdownlint
         if: inputs.run-markdownlint

--- a/.github/workflows/lint-text.yml
+++ b/.github/workflows/lint-text.yml
@@ -43,8 +43,9 @@ on:
           and CI must agree on tool versions. The consumer is then
           responsible for their lockfile's integrity: a committed
           package-lock.json with sha512 integrity hashes is required,
-          and every enabled tool must be a devDependency. yamllint is
-          unaffected (Python, not npm).
+          and every enabled tool must be present in package-lock.json
+          (typically declared as a devDependency in package.json).
+          yamllint is unaffected (Python, not npm).
         type: boolean
         default: false
       timeout-minutes:
@@ -190,8 +191,8 @@ jobs:
         # per-package sha512 integrity, so the trust boundary becomes
         # the consumer's reviewed lockfile rather than this gh-actions
         # repo. The consumer is responsible for committing
-        # package-lock.json and listing every enabled tool as a
-        # devDependency.
+        # package-lock.json with every enabled tool present (typically
+        # as a devDependency in package.json).
         run: |
           if [ ! -f package.json ]; then
             echo "::error::use-consumer-versions=true but package.json is missing in the consumer repo." >&2

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -104,7 +104,12 @@ anything that runs in CI.
 - **npm tools running in workflows** (markdownlint-cli2, prettier,
   cspell): installed via `npm ci` against this repo's
   `package-lock.json`, fetched from this repo at the workflow's own
-  SHA. Per-package sha512 integrity is enforced.
+  SHA. Per-package sha512 integrity is enforced. `lint-text.yml`
+  exposes a `use-consumer-versions: true` opt-in that runs `npm ci`
+  against the consumer's own committed `package-lock.json` instead;
+  npm still enforces sha512 integrity, but the trust boundary becomes
+  the consumer's reviewed lockfile rather than this repo. Use this
+  when CI must agree with the versions a consumer pins locally.
 - **Rust tooling** (cargo-deny, cargo-nextest, cargo-audit,
   cargo-llvm-cov): installed from binary release tarballs with SHA-256
   verification, never via `cargo install` (which would trust crates.io

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `lint-text.yml` `use-consumer-versions` input (boolean, default
+  `false`): opt-in to install markdownlint-cli2, Prettier, and cspell
+  from the consumer repo's own `package.json` + `package-lock.json`
+  via `npm ci` in the workspace, instead of the versions pinned in
+  this gh-actions repo. npm still enforces per-package sha512
+  integrity, so the trust boundary becomes the consumer's reviewed
+  lockfile. Use this when local linting and CI must agree on tool
+  versions (e.g. when a consumer pins `cspell ^8` locally but the
+  pinned default is v10, and dictionary differences across major
+  versions cause divergent results). yamllint is unaffected (#34)
 - `lint-text.yml` `preset` input with a `lean-math` value: opt-in
   Pandoc-flavored academic Markdown config bundle. When set and the
   consumer doesn't ship a local markdownlint or cspell config, the

--- a/docs/workflows/lint-text.md
+++ b/docs/workflows/lint-text.md
@@ -7,15 +7,16 @@ and yamllint YAML validation. Each tool can be toggled independently.
 
 ## Inputs
 
-| Name               | Type    | Default     | Description                               |
-| ------------------ | ------- | ----------- | ----------------------------------------- |
-| `node-version`     | string  | `"24.15.0"` | Node.js version to install                |
-| `run-markdownlint` | boolean | `true`      | Run markdownlint-cli2                     |
-| `run-prettier`     | boolean | `true`      | Run Prettier format check                 |
-| `run-cspell`       | boolean | `false`     | Run cspell spell checker                  |
-| `run-yamllint`     | boolean | `false`     | Run yamllint                              |
-| `preset`           | string  | `""`        | Optional preset config bundle (see below) |
-| `timeout-minutes`  | number  | `10`        | Job timeout in minutes                    |
+| Name                    | Type    | Default     | Description                                                                  |
+| ----------------------- | ------- | ----------- | ---------------------------------------------------------------------------- |
+| `node-version`          | string  | `"24.15.0"` | Node.js version to install                                                   |
+| `run-markdownlint`      | boolean | `true`      | Run markdownlint-cli2                                                        |
+| `run-prettier`          | boolean | `true`      | Run Prettier format check                                                    |
+| `run-cspell`            | boolean | `false`     | Run cspell spell checker                                                     |
+| `run-yamllint`          | boolean | `false`     | Run yamllint                                                                 |
+| `preset`                | string  | `""`        | Optional preset config bundle (see below)                                    |
+| `use-consumer-versions` | boolean | `false`     | Install npm-based lint tools from the consumer's own lockfile (see below)    |
+| `timeout-minutes`       | number  | `10`        | Job timeout in minutes                                                       |
 
 ### Preset configs
 
@@ -50,6 +51,36 @@ Precedence per tool:
 
 The full preset sources live at `presets/<name>/` in this repo.
 
+### Tool versions: pinned vs. consumer
+
+By default, the workflow installs markdownlint-cli2, Prettier, and
+cspell from this repo's own pinned `package.json` and
+`package-lock.json` (fetched at the workflow's own SHA, sha512-verified
+by `npm ci`). This guarantees the same versions across every consumer
+repo, but it can drift from the versions a consumer pins locally in
+their own `package.json`. When the major versions diverge (e.g. cspell
+v8 locally vs. cspell v10 in CI), default-dictionary differences can
+cause linting to pass locally and fail in CI, or vice versa.
+
+Set `use-consumer-versions: true` to install from the consumer's own
+committed `package.json` + `package-lock.json` instead. The workflow
+runs `npm ci` in the workspace, so npm still enforces per-package
+sha512 integrity; the trust boundary becomes the consumer's reviewed
+lockfile rather than this gh-actions repo. Requirements when
+`use-consumer-versions: true`:
+
+- The consumer must have `package.json` and `package-lock.json`
+  committed at the repo root.
+- Every enabled npm-based tool (`run-markdownlint`, `run-prettier`,
+  `run-cspell`) must be listed as a `devDependency` in the consumer's
+  `package.json`. The workflow fails fast with a clear error if either
+  file is missing; if a tool is missing from `devDependencies`, the
+  corresponding run step fails with `command not found`.
+
+`yamllint` is unaffected by this input (Python tool, installed via
+`uv pip install --require-hashes` from this repo's
+`requirements/yamllint.txt`).
+
 ## Usage
 
 ```yaml
@@ -70,4 +101,16 @@ jobs:
       run-cspell: true
       run-prettier: false
       preset: lean-math
+```
+
+Repo that wants CI to use its own pinned tool versions from
+`package.json` (so local linting and CI agree):
+
+```yaml
+jobs:
+  text:
+    uses: cboone/gh-actions/.github/workflows/lint-text.yml@v3.0.0
+    with:
+      run-cspell: true
+      use-consumer-versions: true
 ```

--- a/docs/workflows/lint-text.md
+++ b/docs/workflows/lint-text.md
@@ -72,10 +72,11 @@ lockfile rather than this gh-actions repo. Requirements when
 - The consumer must have `package.json` and `package-lock.json`
   committed at the repo root.
 - Every enabled npm-based tool (`run-markdownlint`, `run-prettier`,
-  `run-cspell`) must be listed as a `devDependency` in the consumer's
-  `package.json`. The workflow fails fast with a clear error if either
-  file is missing; if a tool is missing from `devDependencies`, the
-  corresponding run step fails with `command not found`.
+  `run-cspell`) must be present in the consumer's `package-lock.json`,
+  typically declared as a `devDependency` in `package.json`. The
+  workflow fails fast with a clear error if either file is missing;
+  if a tool is missing from the lockfile, the corresponding run step
+  fails with `command not found`.
 
 `yamllint` is unaffected by this input (Python tool, installed via
 `uv pip install --require-hashes` from this repo's


### PR DESCRIPTION
## Summary

- Adds `use-consumer-versions` boolean input (default `false`) to `lint-text.yml`. When `true`, the workflow runs `npm ci` against the consumer repo's own committed `package.json` + `package-lock.json` instead of fetching this repo's pinned lockfile. npm still enforces per-package sha512 integrity, so the trust boundary becomes the consumer's reviewed lockfile rather than this gh-actions repo.
- Default behavior is unchanged: with `use-consumer-versions: false`, the existing pinned-from-gh-actions install runs as before.
- Lets consumers pin npm-based lint tools (markdownlint-cli2, Prettier, cspell) to the same versions locally and in CI, eliminating drift like the `cspell ^8` (local) vs. v10 (CI) case in `cboone/life`. yamllint is unaffected (Python, hash-pinned via uv).
- Documents the tradeoff in `docs/workflows/lint-text.md` and the trust-model section of `AGENTS.md`. CHANGELOG entry added under `[Unreleased]`.

Closes #34

## Test plan

- [ ] `actionlint .github/workflows/lint-text.yml` passes
- [ ] `make lint format-check lint-md spell lint-yaml` passes
- [ ] CI integration (self-hosting `run-ci.yml`) passes with the default path (existing behavior)
- [ ] Manual smoke: a downstream repo (e.g. `cboone/life`) sets `use-consumer-versions: true` and confirms its locally pinned `cspell ^8` is what runs in CI