### PR TITLE
feat: validate :macos/:linux Homebrew depends_on against targets matrix

### DIFF
--- a/.github/workflows/release-rust-binaries.yml
+++ b/.github/workflows/release-rust-binaries.yml
@@ -253,6 +253,8 @@ jobs:
         env:
           HOMEBREW_TAP: ${{ inputs.homebrew-tap }}
           FORMULA_PATH: ${{ inputs.homebrew-formula-path }}
+          TARGETS: ${{ inputs.targets }}
+          DEPENDS_ON: ${{ inputs.homebrew-depends-on }}
         run: |
           if [ -z "${HOMEBREW_TAP}" ]; then
             echo "Error: homebrew-tap is required when update-homebrew is true" >&2
@@ -261,6 +263,58 @@ jobs:
           if [ -z "${FORMULA_PATH}" ]; then
             echo "Error: homebrew-formula-path is required when update-homebrew is true" >&2
             exit 1
+          fi
+
+          # Cross-check ':macos'/':linux' constraints in homebrew-depends-on
+          # against the targets matrix so the formula can't both restrict to
+          # one OS and ship bottles for the other.
+          declared_macos=false
+          declared_linux=false
+          if [ -n "${DEPENDS_ON}" ]; then
+            while IFS= read -r dep; do
+              dep="${dep#"${dep%%[![:space:]]*}"}"
+              dep="${dep%"${dep##*[![:space:]]}"}"
+              case "${dep}" in
+                :macos) declared_macos=true ;;
+                :linux) declared_linux=true ;;
+              esac
+            done <<< "${DEPENDS_ON}"
+          fi
+
+          if [ "${declared_macos}" = "true" ] || [ "${declared_linux}" = "true" ]; then
+            readarray -t target_triples < <(printf '%s' "${TARGETS}" | jq -r '.[].target')
+            if [ "${declared_macos}" = "true" ]; then
+              conflicts=()
+              for t in "${target_triples[@]}"; do
+                case "${t}" in
+                  *-apple-darwin) ;;
+                  *) conflicts+=("${t}") ;;
+                esac
+              done
+              if [ ${#conflicts[@]} -gt 0 ]; then
+                echo "Error: homebrew-depends-on declares ':macos' but targets" \
+                  "includes non-macOS target(s): ${conflicts[*]}." >&2
+                echo "Either remove ':macos' from homebrew-depends-on or" \
+                  "restrict targets to *-apple-darwin entries." >&2
+                exit 1
+              fi
+            fi
+            if [ "${declared_linux}" = "true" ]; then
+              conflicts=()
+              for t in "${target_triples[@]}"; do
+                case "${t}" in
+                  *-linux-*) ;;
+                  *) conflicts+=("${t}") ;;
+                esac
+              done
+              if [ ${#conflicts[@]} -gt 0 ]; then
+                echo "Error: homebrew-depends-on declares ':linux' but targets" \
+                  "includes non-Linux target(s): ${conflicts[*]}." >&2
+                echo "Either remove ':linux' from homebrew-depends-on or" \
+                  "restrict targets to *-linux-* entries." >&2
+                exit 1
+              fi
+            fi
           fi
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   symbols (e.g. `:macos`), other lines are emitted as quoted strings
   (e.g. `openssl`). Needed for macOS-only tools and tools with
   library dependencies (#31)
+- Fail-fast validation in `release-rust-binaries.yml` when
+  `homebrew-depends-on` declares `:macos` or `:linux` but the `targets`
+  matrix includes a target for the other platform. Prevents generating a
+  self-contradictory formula that restricts to one OS while shipping
+  bottles for the other (#56)
 - Reusable workflow `run-lean-ci.yml` for Lean Lake projects using
   `leanprover/lean-action`. Builds via lean-action (with elan toolchain
   caching and pass-through control over the Mathlib build cache), then

--- a/docs/workflows/release-rust-binaries.md
+++ b/docs/workflows/release-rust-binaries.md
@@ -133,3 +133,9 @@ Lines starting with `:` are emitted as Ruby symbols (constraints
 like `:macos` or `:linux`). Other lines are emitted as quoted
 strings (formula dependencies like `openssl`). Blank lines are
 ignored.
+
+When `homebrew-depends-on` includes `:macos` or `:linux`, the workflow
+cross-checks the constraint against the `targets` matrix and fails fast
+if they conflict (for example, `:macos` declared alongside a
+`*-unknown-linux-*` target). This prevents generating a self-contradictory
+formula that restricts to one OS while shipping bottles for the other.


### PR DESCRIPTION
## Summary

- Extend the Homebrew job's `Validate inputs` step in `release-rust-binaries.yml` to fail fast when `homebrew-depends-on` declares `:macos` or `:linux` but the `targets` matrix includes a target for the other platform.
- Mirror the formula emitter's per-line trimming when parsing `:macos` / `:linux` symbols, then cross-check against `inputs.targets` (parsed via `jq`); error messages name the conflicting targets and the offending constraint.
- Document the new fail-fast behavior in `docs/workflows/release-rust-binaries.md` and add a `CHANGELOG.md` entry under `Unreleased`.

## Test plan

- [ ] Locally exercise the validation logic across the matrix of cases (`:macos` with all-darwin, `:macos` with mixed targets, `:linux` with all-linux, `:linux` with mixed targets, no constraints, plain-string deps only, whitespace handling, musl Linux targets).
- [ ] Consume the updated workflow from a Rust CLI repo with `homebrew-depends-on: ":macos"` and a Linux target in `targets`, and confirm the workflow fails with the expected error before any tap commit is pushed.
- [ ] Consume the updated workflow with a valid macOS-only configuration (`:macos` plus only `*-apple-darwin` targets) and confirm the formula updates as before.

## Closes

Closes #56
