### PR TITLE
feat(lint-text): explicit missing-tool validation for use-consumer-versions

### DIFF
--- a/.github/workflows/lint-text.yml
+++ b/.github/workflows/lint-text.yml
@@ -224,16 +224,18 @@ jobs:
           RUN_CSPELL: ${{ inputs.run-cspell }}
         run: |
           missing=0
+          fix="add it to devDependencies in package.json"
+          fix="${fix} and commit the updated package-lock.json"
           if [ "${RUN_MARKDOWNLINT}" = "true" ] && ! command -v markdownlint-cli2 >/dev/null 2>&1; then
-            echo "::error::markdownlint-cli2 is enabled but not installed; add it to devDependencies in package.json and commit the updated package-lock.json" >&2
+            echo "::error::markdownlint-cli2 is enabled but not installed; ${fix}" >&2
             missing=1
           fi
           if [ "${RUN_PRETTIER}" = "true" ] && ! command -v prettier >/dev/null 2>&1; then
-            echo "::error::prettier is enabled but not installed; add it to devDependencies in package.json and commit the updated package-lock.json" >&2
+            echo "::error::prettier is enabled but not installed; ${fix}" >&2
             missing=1
           fi
           if [ "${RUN_CSPELL}" = "true" ] && ! command -v cspell >/dev/null 2>&1; then
-            echo "::error::cspell is enabled but not installed; add it to devDependencies in package.json and commit the updated package-lock.json" >&2
+            echo "::error::cspell is enabled but not installed; ${fix}" >&2
             missing=1
           fi
           if [ "${missing}" -ne 0 ]; then

--- a/.github/workflows/lint-text.yml
+++ b/.github/workflows/lint-text.yml
@@ -207,6 +207,39 @@ jobs:
           npm ci --ignore-scripts --include=dev --no-audit --no-fund
           printf '%s\n' "${GITHUB_WORKSPACE}/node_modules/.bin" >> "${GITHUB_PATH}"
 
+      - name: Validate consumer-installed lint tools
+        if: >-
+          ${{ inputs.use-consumer-versions
+          && (inputs.run-markdownlint || inputs.run-prettier || inputs.run-cspell) }}
+        # When use-consumer-versions is true, npm ci installs only what
+        # the consumer's package-lock.json declares. If an enabled tool
+        # is missing from that lockfile, the run step would fail later
+        # with a generic 'command not found'. Surface a targeted
+        # ::error:: annotation here so the GitHub UI points the consumer
+        # at the actual fix (edit package.json, re-run npm install,
+        # commit the updated lockfile).
+        env:
+          RUN_MARKDOWNLINT: ${{ inputs.run-markdownlint }}
+          RUN_PRETTIER: ${{ inputs.run-prettier }}
+          RUN_CSPELL: ${{ inputs.run-cspell }}
+        run: |
+          missing=0
+          if [ "${RUN_MARKDOWNLINT}" = "true" ] && ! command -v markdownlint-cli2 >/dev/null 2>&1; then
+            echo "::error::markdownlint-cli2 is enabled but not installed; add it to devDependencies in package.json and commit the updated package-lock.json" >&2
+            missing=1
+          fi
+          if [ "${RUN_PRETTIER}" = "true" ] && ! command -v prettier >/dev/null 2>&1; then
+            echo "::error::prettier is enabled but not installed; add it to devDependencies in package.json and commit the updated package-lock.json" >&2
+            missing=1
+          fi
+          if [ "${RUN_CSPELL}" = "true" ] && ! command -v cspell >/dev/null 2>&1; then
+            echo "::error::cspell is enabled but not installed; add it to devDependencies in package.json and commit the updated package-lock.json" >&2
+            missing=1
+          fi
+          if [ "${missing}" -ne 0 ]; then
+            exit 1
+          fi
+
       - name: Run markdownlint
         if: inputs.run-markdownlint
         run: markdownlint-cli2 "**/*.md"

--- a/docs/workflows/lint-text.md
+++ b/docs/workflows/lint-text.md
@@ -74,9 +74,12 @@ lockfile rather than this gh-actions repo. Requirements when
 - Every enabled npm-based tool (`run-markdownlint`, `run-prettier`,
   `run-cspell`) must be present in the consumer's `package-lock.json`,
   typically declared as a `devDependency` in `package.json`. The
-  workflow fails fast with a clear error if either file is missing;
-  if a tool is missing from the lockfile, the corresponding run step
-  fails with `command not found`.
+  workflow fails fast with a clear error if either file is missing.
+  After `npm ci`, a validation step checks that each enabled tool's
+  binary resolves on `PATH` and emits a targeted `::error::` annotation
+  naming the missing tool and the fix (add it to `devDependencies` in
+  `package.json` and commit the updated `package-lock.json`) before the
+  run step would otherwise fail with `command not found`.
 
 `yamllint` is unaffected by this input (Python tool, installed via
 `uv pip install --require-hashes` from this repo's


### PR DESCRIPTION
## Summary

- Add a `Validate consumer-installed lint tools` step to `lint-text.yml`, gated on `inputs.use-consumer-versions` and at least one enabled npm tool, that checks each enabled tool's binary on `PATH` after `npm ci` and emits a targeted `::error::<tool> is enabled but not installed; add it to devDependencies in package.json and commit the updated package-lock.json` annotation, exiting non-zero before the run step would fail with `command not found`.
- Default pinned-versions install path is unaffected; the step is skipped entirely when `use-consumer-versions` is false and is a no-op when all enabled tools resolve.
- Update `docs/workflows/lint-text.md` to describe the new validation step and the targeted annotation in place of the prior `command not found` fallback wording.
- Hoist the shared error-message suffix into a `fix` variable to keep `echo "::error::..."` lines under the 120-char yamllint line-length limit.

## Test plan

- [ ] Call `lint-text.yml` from a downstream repo with `use-consumer-versions: true` and a `package-lock.json` missing one of the enabled tools; confirm a targeted `::error::` annotation names the missing tool and the run step does not execute.
- [ ] Call `lint-text.yml` with `use-consumer-versions: true` and all enabled tools present in the lockfile; confirm the validation step is a no-op and the lint runs succeed.
- [ ] Call `lint-text.yml` with the default `use-consumer-versions: false`; confirm the validation step is skipped via `if:` and the pinned-versions install path runs unchanged.

## Closes

Closes #59
